### PR TITLE
[손창성] 더 이상 `import React from 'react'`를 하지 않아도 되는 이유

### DIFF
--- a/scs/2024-03.08.md
+++ b/scs/2024-03.08.md
@@ -1,0 +1,51 @@
+### 더 이상 `import React from 'react'`를 하지 않아도 되는 이유 
+
+React v17.0 업데이트 이후로 `import React from 'react'` 구문을 더 이상 사용하지 않아도 된다. JSX Transform의 새로운 버전 도입으로 인한 결과이다.
+
+브라우저는 기본적으로 JSX를 이해하지 못하므로 JSX 코드를 JavaScript로 변환할 필요가 있다. Babel이라는 컴파일러가 바로 JSX로 작성한 코드를 JavaScript 코드로 변환하는 역할이다. JSX를 JavaScript로 변환해주는 것을 일반적으로 **JSX Transform** 이라고 부른다.
+
+기존 JSX Transform는 JSX 요소를 `React.createElement`를 호출하는 코드로 변환하였다.
+
+```jsx
+// 원본 소스 코드
+import React from 'react';
+
+function App() {
+  return <h1>Hello World</h1>;
+}
+```
+
+```jsx
+// Javascript로 변환한 코드
+import React from 'react';
+
+function App() {
+  return React.createElement('h1', null, 'Hello world');
+}
+```
+
+이 과정에서 'React' 객체가 필요해 `import React from 'react'`를 사용했던 것이다. JSX를 변환하기 위해서 React의 `createElement()`에 의존해야 한다는 점과 `createElement()`의 성능 이슈로 React팀은 이를 개선하기로 한다.
+
+> [Introducing the New JSX Transform](https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html#whats-different-in-the-new-transform)
+
+새로운 JSX Transform은 `React.createElement` 대신 `jsx`를 호출하는 코드로 변환한다. 새로운 JSX Transform은 `react/jsx-runtime` 모듈을 자동으로 가져 오기 때문에 JSX를 사용할 때 더 이상 React를 호출할 필요가 없다.
+
+```jsx
+// 원본 소스 코드
+function App() {
+  return <h1>Hello World</h1>;
+}
+```
+
+```jsx
+// Javascript로 변환한 코드
+import {jsx as _jsx} from 'react/jsx-runtime';
+
+function App() {
+  return _jsx('h1', { children: 'Hello world' });
+}
+```
+
+이 함수들은 패키지에서 가져오지 않고, 바벨과 같은 트랜스파일러가 자동으로 삽입한다. 이러한 이유로 `import React from 'react'`를 사용하지 않아도 JSX를 사용할 수 있게 되었다.
+
+'import React'를 사용하지 않아도 되므로 코드 작성이 조금 더 간결해졌다. 또한, 불필요한 모듈을 가져오지 않기 때문에 번들 사이즈가 줄어들어 성능 개선에도 이점이 있다.


### PR DESCRIPTION
### 더 이상 `import React from 'react'`를 하지 않아도 되는 이유 

React v17.0 업데이트 이후로 `import React from 'react'` 구문을 더 이상 사용하지 않아도 된다. JSX Transform의 새로운 버전 도입으로 인한 결과이다.

브라우저는 기본적으로 JSX를 이해하지 못하므로 JSX 코드를 JavaScript로 변환할 필요가 있다. Babel이라는 컴파일러가 바로 JSX로 작성한 코드를 JavaScript 코드로 변환하는 역할이다. JSX를 JavaScript로 변환해주는 것을 일반적으로 **JSX Transform** 이라고 부른다.

기존 JSX Transform는 JSX 요소를 `React.createElement`를 호출하는 코드로 변환하였다.

```jsx
// 원본 소스 코드
import React from 'react';

function App() {
  return <h1>Hello World</h1>;
}
```

```jsx
// Javascript로 변환한 코드
import React from 'react';

function App() {
  return React.createElement('h1', null, 'Hello world');
}
```

이 과정에서 'React' 객체가 필요해 `import React from 'react'`를 사용했던 것이다. JSX를 변환하기 위해서 React의 `createElement()`에 의존해야 한다는 점과 `createElement()`의 성능 이슈로 React팀은 이를 개선하기로 한다.

> [Introducing the New JSX Transform](https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html#whats-different-in-the-new-transform)

새로운 JSX Transform은 `React.createElement` 대신 `jsx`를 호출하는 코드로 변환한다. 새로운 JSX Transform은 `react/jsx-runtime` 모듈을 자동으로 가져 오기 때문에 JSX를 사용할 때 더 이상 React를 호출할 필요가 없다.

```jsx
// 원본 소스 코드
function App() {
  return <h1>Hello World</h1>;
}
```

```jsx
// Javascript로 변환한 코드
import {jsx as _jsx} from 'react/jsx-runtime';

function App() {
  return _jsx('h1', { children: 'Hello world' });
}
```

이 함수들은 패키지에서 가져오지 않고, 바벨과 같은 트랜스파일러가 자동으로 삽입한다. 이러한 이유로 `import React from 'react'`를 사용하지 않아도 JSX를 사용할 수 있게 되었다.

'import React'를 사용하지 않아도 되므로 코드 작성이 조금 더 간결해졌다. 또한, 불필요한 모듈을 가져오지 않기 때문에 번들 사이즈가 줄어들어 성능 개선에도 이점이 있다.