### PR TITLE
[손창성] SOP와 CORS

### DIFF
--- a/scs/2024-03-13.md
+++ b/scs/2024-03-13.md
@@ -1,0 +1,27 @@
+## SOP와 CORS
+
+CORS 에러는 한 사이트에서 주소가 다른 서버로 HTTP 요청을 보냈을 때 브라우저에서 발생하는 문제이다. 도메인이 다르면 요청을 주고 받을 수 없는 것이 웹 브라우저의 기본 정책이므로. 하지만 이 기존 정책 때문에 불편한 점이 발생한다.
+
+예를 들어, 구축한 웹사이트에서 날씨를 알려주기 위해 날씨 API를 이용하려고 한다. 구축한 웹페이지의 도메인은 `www.mysite.com`, 날씨 API 도메인은 `www.weather.com`이라고 가정하자. 서로 도메인이 다르기 때문에 구축한 웹페이지에서 요청을 하면 CORS 에러를 만나게 된다. 이처럼 웹 생태계가 다양해 지면서 여러 서비스들간에 자유롭게 데이터를 주고받을 필요가 생겼다. 합의된 출처들 간에 합법적으로 허용해주기 위해 어떤 기준을 충족시키면 리소스 공유가 되도록 만들어진 메커니즘이 바로 CORS이다.
+
+>  [CORS(Cross-Origin Resource Sharing)이 나오게 된 배경 이야기 - YouTube](https://www.youtube.com/watch?v=yTzAjidyyqs)
+
+### SOP(Same-Origin Policy)
+
+앞에서 도메인이 다르면 요청을 주고 받을 수 없었던 정책이 바로 SOP이다. 보안을 위협하는 문서나 스크립트로부터 보호하기 위해서다. SOP는 웹 브라우저 보안을 위한 보안 방식이므로 브라우저를 거치지 않은 서버 간 통신을 할 때는 적용되지 않는다.
+
+> **동일 출처 정책**(same-origin policy)은 어떤 [출처](https://developer.mozilla.org/ko/docs/Glossary/Origin)에서 불러온 문서나 스크립트가 다른 출처에서 가져온 리소스와 상호작용하는 것을 제한하는 중요한 보안 방식 https://developer.mozilla.org/ko/docs/Web/Security/Same-origin_policy
+
+**출처**(origin)는 접근할 때 사용하는 URL의 스킴(프로토콜), 호스트(도메인), 포트번호로 정의됩니다. 두 URL의 스킴, 호스트, 포트번호가 모두 같아야 동일한 출처로 판단한다.
+
+### CORS(Cross-Origin Resource Sharing)
+
+> **교차 출처 리소스 공유**(Cross-Origin Resource Sharing, [CORS](https://developer.mozilla.org/ko/docs/Glossary/CORS))는 추가 [HTTP](https://developer.mozilla.org/ko/docs/Glossary/HTTP) 헤더를 사용하여, 한 [출처](https://developer.mozilla.org/ko/docs/Glossary/Origin)에서 실행 중인 웹 애플리케이션이 다른 출처의 선택한 자원에 접근할 수 있는 권한을 부여하도록 브라우저에 알려주는 체제 https://developer.mozilla.org/ko/docs/Web/HTTP/CORS
+
+쉽게 말해 다른 출처간에 리소스를 공유할 수 있도록 하는 방법.
+
+#### CORS 기본적인 동작 방식
+
+브라우저는 다른 출처의 리소스를 요청할 때 Origin이라는 header(데이터가 다른 곳으로 전송될 때 데이터의 맨 앞쪽에 붙는 보충 정보)를 추가한다. Origin에는 요청하는 사용자의 스킴과 도메인, 포트가 담긴다.
+
+요청을 받은 서버는 응답 헤더에 지정된 [Access-Control-Allow-Origin](https://developer.mozilla.org/ko/docs/Web/HTTP/Headers/Access-Control-Allow-Origin) 정보를 실어서 보낸다. 이후 브라우저는 Origin에 보낸 출처값이 서버의 응답 헤더에 담긴 Access-Control-Allow-Origin에 똑같이 있으면 안전한 요청으로 간주한다. 즉, 서버 응답 헤더의 **Access-Control-Allow-Origin**의 값이 요청을 보낸 출처와 다르다면 CORS 정책을 위반했다고 판단하여 에러를 발생시키는 것.


### PR DESCRIPTION
## SOP와 CORS

CORS 에러는 한 사이트에서 주소가 다른 서버로 HTTP 요청을 보냈을 때 브라우저에서 발생하는 문제이다. 도메인이 다르면 요청을 주고 받을 수 없는 것이 웹 브라우저의 기본 정책이므로. 하지만 이 기존 정책 때문에 불편한 점이 발생한다.

예를 들어, 구축한 웹사이트에서 날씨를 알려주기 위해 날씨 API를 이용하려고 한다. 구축한 웹페이지의 도메인은 `www.mysite.com`, 날씨 API 도메인은 `www.weather.com`이라고 가정하자. 서로 도메인이 다르기 때문에 구축한 웹페이지에서 요청을 하면 CORS 에러를 만나게 된다. 이처럼 웹 생태계가 다양해 지면서 여러 서비스들간에 자유롭게 데이터를 주고받을 필요가 생겼다. 합의된 출처들 간에 합법적으로 허용해주기 위해 어떤 기준을 충족시키면 리소스 공유가 되도록 만들어진 메커니즘이 바로 CORS이다.

>  [[CORS(Cross-Origin Resource Sharing)이 나오게 된 배경 이야기 - YouTube](https://www.youtube.com/watch?v=yTzAjidyyqs)](https://www.youtube.com/watch?v=yTzAjidyyqs)

### SOP(Same-Origin Policy)

앞에서 도메인이 다르면 요청을 주고 받을 수 없었던 정책이 바로 SOP이다. 보안을 위협하는 문서나 스크립트로부터 보호하기 위해서다. SOP는 웹 브라우저 보안을 위한 보안 방식이므로 브라우저를 거치지 않은 서버 간 통신을 할 때는 적용되지 않는다.

> **동일 출처 정책**(same-origin policy)은 어떤 [[출처](https://developer.mozilla.org/ko/docs/Glossary/Origin)](https://developer.mozilla.org/ko/docs/Glossary/Origin)에서 불러온 문서나 스크립트가 다른 출처에서 가져온 리소스와 상호작용하는 것을 제한하는 중요한 보안 방식 https://developer.mozilla.org/ko/docs/Web/Security/Same-origin_policy

**출처**(origin)는 접근할 때 사용하는 URL의 스킴(프로토콜), 호스트(도메인), 포트번호로 정의됩니다. 두 URL의 스킴, 호스트, 포트번호가 모두 같아야 동일한 출처로 판단한다.

### CORS(Cross-Origin Resource Sharing)

> **교차 출처 리소스 공유**(Cross-Origin Resource Sharing, [[CORS](https://developer.mozilla.org/ko/docs/Glossary/CORS)](https://developer.mozilla.org/ko/docs/Glossary/CORS))는 추가 [[HTTP](https://developer.mozilla.org/ko/docs/Glossary/HTTP)](https://developer.mozilla.org/ko/docs/Glossary/HTTP) 헤더를 사용하여, 한 [[출처](https://developer.mozilla.org/ko/docs/Glossary/Origin)](https://developer.mozilla.org/ko/docs/Glossary/Origin)에서 실행 중인 웹 애플리케이션이 다른 출처의 선택한 자원에 접근할 수 있는 권한을 부여하도록 브라우저에 알려주는 체제 https://developer.mozilla.org/ko/docs/Web/HTTP/CORS

쉽게 말해 다른 출처간에 리소스를 공유할 수 있도록 하는 방법.

#### CORS 기본적인 동작 방식

브라우저는 다른 출처의 리소스를 요청할 때 Origin이라는 header(데이터가 다른 곳으로 전송될 때 데이터의 맨 앞쪽에 붙는 보충 정보)를 추가한다. Origin에는 요청하는 사용자의 스킴과 도메인, 포트가 담긴다.

요청을 받은 서버는 응답 헤더에 지정된 [[Access-Control-Allow-Origin](https://developer.mozilla.org/ko/docs/Web/HTTP/Headers/Access-Control-Allow-Origin)](https://developer.mozilla.org/ko/docs/Web/HTTP/Headers/Access-Control-Allow-Origin) 정보를 실어서 보낸다. 이후 브라우저는 Origin에 보낸 출처값이 서버의 응답 헤더에 담긴 Access-Control-Allow-Origin에 똑같이 있으면 안전한 요청으로 간주한다. 즉, 서버 응답 헤더의 **Access-Control-Allow-Origin**의 값이 요청을 보낸 출처와 다르다면 CORS 정책을 위반했다고 판단하여 에러를 발생시키는 것.