### PR TITLE
[손창성] 구매한 git 강의 수강

### DIFF
--- a/scs/2024-03-19.md
+++ b/scs/2024-03-19.md
@@ -1,0 +1,246 @@
+## 2. 셋업하기
+
+### 2.1 필요한 아이들 설치
+
+터미널에서 명령어를 사용하는 것을 추천
+
+### 2.2 사용자 설정 및 필요한 셋팅들
+
+windows: `git config --global core.autocrlf true`
+
+mac: `git config --global core.autocrlf input`
+
+운영체제마다 줄바꿈을 할 때 들어가는 문자열이 다르기 때문에 
+
+Windows는 `\r\n` carriage-return과 line feed
+
+mac은 `\n` line feed
+
+이러한 설정 때문에 변경 사항이 없더라도 줄바꿈 문자열이 달라져서 
+
+`core.autocrlf`는 줄바꿈 문자를 설정할 수 있다. Windows의 경우 true로 설정하면 git에 저장할 때는 `\r`을 삭제한 `\n`만 저장이 되고 가져올 때는 자동으로 `\r`이 붙어져 `\r\n`을 가져온다. 
+
+Mac에서 input으로 설정하면 `\r`을 삭제하여 git에 저장한다. carriage-return을 사용하지 않음에도 이를 삭제하는 이유는 복사해서 가져온 텍스트에 carriage-return이 들어가 있을 수 있기 때문이다. 
+
+### 2.3 깃을 공부하는 포인트
+
+Git에 관련된 전체적인 명령어를 이해하고 사용하는 연습
+
+`git 명령어 -옵션`
+
+### 2.4 깃 초기화 하고 삭제하기
+
+`mkdir git`: 폴더 생성
+
+`cd git`: 폴더로 이동
+
+`git init`: git 초기화 -> `.git` 폴더 생성. git repository와 관련된 정보를 포함.
+
+`rm -rf .git`: git 삭제
+
+#### git alias 사용하기
+
+`git config --global alias.st status` 라고 별칭(alias)를 지정하면 git status 명령어 대신 git st로 사용할 수 있다. 
+
+`git config --h`: git 명령어 확인
+
+## 3. 기본 명령어 정복하기
+
+### 3.1 깃의 중요한 컨셉 이해하기
+
+깃을 잘 이해하기 위해서는 workflow를 이해하는 것이 중요하다.
+
+git은 총 3가지의 작업 환경으로 나누어져 있다. 
+
+- working directory: 파일들을 수정하는 작업 디렉토리
+- staging area: 버전 히스토리에 저장할 수 있는 파일 장소
+- .git directiory: 버전의 히스토리를 가지고 있는 깃 리파지토리
+
+
+
+작업을 하고 있는 디렉토리(working directory)에서 수정을 마치면 staging area로 옮긴다. commit 이라는 명령어를 이용해 staging area에 있는 파일들을 깃 버전 히스토리(.git directory)에 저장한다. 
+
+git directory에 저장된 파일들은 checkout 명령어를 이용해 언제든지 원하는 버전으로 이동할 수 있다.
+
+git history는 로컬 컴퓨터에만 저장되기 때문에 문제가 생기면 파일들이 없어질 수 있다. 그렇기 때문에 다른 서버에 저장할 필요가 있다. push 명령어를 이용해서 서버에 .git directory를 업로드할 수 있다. 
+
+서버에서 로컬로 다운로드 받고 싶을 때는 pull 명령어. 각각의 버전에 포함된 정보는 다음과 같다.
+
+- snapshot된 정보를 기반으로 고유한 hash 코드를 생성하고 hash code를 아이디로 정보를 참조할 수 있다. 아이디 뿐만 아니라 버전에 관한 메시지와 변경자와 변경시간 등의 정보도 포함한다.
+
+working directory는 untracked와 tracked로 나뉜다.
+
+- untracked: 새로 만들어졌거나 git이 존재하던 폴더에서 git 폴더를 삭제했을 때
+- tracked: git이 이미 관리하고 있는 파일
+  - git이 추적하고 있는 파일들 중 수정이 되었는지 여부에 따라 modified와 unmodified로 구분
+    - unmodified는 이전 버전과 비교해 변경되지 않았기 때문에 수정이 된 modified만 파일만 staging area로 이동할 수 있다. 
+
+### 3.2 로컬 파일들 추가하기 add
+
+변경점이 생겼을 때 commit하지 않은 파일들을 
+
+`git status`: 현재 파일들의 상태 확인
+
+`git add`: staging area로 옮길 파일을 추가
+
+`git rm --cached *`: git add한 파일들을 untracked로 변경 
+
+`*`는 디렉토리의 모든 파일을 의미. 만약 파일이 삭제되었다면? staging area에 추가되지 않는다.
+
+`.`은 모든 파일들을 포함해 staging area에 추가한다. 
+
+### 3.3  절대 추가 하면 안되는 아이들 ignore
+
+gitignore은 추적하고 싶지 않은, git과 github에 올리고 싶지 않은 파일을 정의한다.
+
+### 3.4 현재 상태 확인하기 status
+
+`git status`는 작업 내용들을 간단하게 확인할 수 있는 명령어
+
+`git status -h`를 입력하면 git status에 대한 명령어를 자세히 알고 싶을 때
+
+`git status -s` 간단하게 확인 가능
+
+### 3.5 파일 비교하기 diff
+
+git status는 어떤 파일이 수정되었고 staging area에 있는지 확인할 수는 있지만 정확히 어떤 내용이 수정되었는 지는 확인할 수 없다. 
+
+`git diff`를 입력하면 working directory를 기준으로 변경사항을 확인
+
+`@@ -1 +1,2 @@` 의미 `-1`은 이전 파일, `+1,2`는 현재 파일에서 첫 번째 라인에서 두 줄을 확인하라는 뜻
+
+### 3.6 버전 등록하기 commit
+
+서버에 올릴 파일들을 staging area에 옮겨 놓았다. 첫 번째 버전을 만들어 보자.
+
+버전을 만들 때는 commit 명령어를 사용한다. 
+
+`git commit`
+
+`[브랜치 해시코드 앞부분] 제목`
+
+`git log` 깃 히스토리 확인
+
+`git commit -m "커밋 메시지"`
+
+모든 변경점을 한 번에 올리려면 `git commit -am "커밋 메시지"`
+
+### 3.7 커밋할 때 팁
+
+로컬에 있는 .git directory는 history가 모여 있다. 작업한 내용들을 버전으로 나누어 관리할 수 있도록.
+
+history에는 전체 애플리케이션을 만들어 저장하는 것이 아니라 세분화, 기능별로 나누는 것이 중요하다. 또한, 의미없는 커밋보다는 작업단위, 의미 있는 이름을 부여해 작업 내용을 확인할 수 있고 원하지 않은 변경사항을 취소할 수 있다. 
+
+커밋 메시지는 현재형으로, 동사로 만들어진다. init, add, fix 
+
+커밋 메시지 작성할 때 주의할 점: 하나의 커밋에 다른 내용들을 끼워넣지 않을 것. 코드를 리뷰할 때 혼동이 올 뿐만 아니라 히스토리를 추적하기 어렵다. 
+
+너무 크지도, 작지도 않게 의미 있는 단위로 커밋하기
+
+### 3.8 소스트리로 커밋하기
+
+
+
+### 3.9 파일 변경시 유용한 팁
+
+파일을 삭제할 때는 `rm` 명령어를 사용하면 파일이 삭제된 내용은 staging area에 포함되지 않는다. 커밋하기 위해서는 add를 해야한다. `git rm` 명령어를 이용해 파일을 삭제하면 바로 staging area에 추가해준다. 
+
+`mv a b` 파일 이름을 변경할 때는 기존의 파일(a)이 삭제되었고 b가 새로 생성되었다고 간주한다.
+
+`git mv a b`를 이용하면 이름이 변경된 것이 바로 staging area에 추가된다.
+
+### 3.10 버전들 목록 보기 log
+
+git history를 볼 수 있는 `git log` - 위에가 최신 아래가 옛날
+
+`git log --p`: 수정된 파일 내용도 확인 가능 (변경된 파일 내용도 확인하고 싶을 때 )
+
+`git log --oneline` 간단하게 히스토리를 확인
+
+
+
+`HEAD`란?  
+
+a라는 커밋을 하고 b,c 를 차례로 커밋 했다고 하자. 그렇다면 b는 a를 c는 b를 '참조'하고 있다. b가 a를 가리키는 포인터가 생성이 된다. HEAD는 지금 현재 시점의 버전. 
+
+`HEAD~1`은 현재 HEAD의 하나 이전 버전.
+
+이렇게 만들어진 커밋들은 원할 때 언제든지 돌아갈 수 있다. b로 돌아가고 싶다면 checkout 
+
+head는 현재 바라보고 있는 커밋을 가리킨다는 의미이다. git log를 하면 해시코드가 있다. 해시코드를 복사한 다음 `git checkout 해시코드`를 입력하면 해당 커밋으로 돌아간다. 
+
+### 3.11 로그 이쁘게 만들기 (엘리의 포맷 공유)
+
+git log를 볼 때 원하는 정보를 볼 수 있도록 포맷팅 하는 방법
+
+`git log --pretty=oneline` 
+
+원하는 방식대로 포맷을 만들 수 있다.
+
+`git log --pretty=format:"$h $an $ar $s"`
+
+`git log --oneline --graph --all` 
+
+
+
+`git config --global alias.hist "git log --graph --all --pretty=format:'%C(yellow)[%ad]%C(reset) %C(green)[%h]%C(reset) | %C(white)%s %C(bold red){{%an}}%C(reset) %C(blue)%d%C(reset)' --date=short"` 그래프까지 포함해 예쁘게 로그 보는 방법
+
+### 3.12 로그 심화 내용
+
+깃 로그를 잘 활용한다는 것은 깃 히스토리를 잘 확인하고 원하는 버전을 빠르게 찾아낼 수 있기 때문이다. 
+
+`git log -3`: 최근 3개의 커밋 확인
+
+### 3.14 태그는 왜 필요할까? tag
+
+깃 히스토리에 커밋이 쌓이고 로그가 길어진다면 특정 시점으로 돌아가기 어렵다.
+
+커밋에 태그를 달아두면 원하는 시점으로 쉽게 돌아갈 수 있다. 대부분 release할 때 버전을 많이 태그해둔다. 태그는 특정 부분에 태그를 해둠으로써 언제 release 되었는지 확인하고 
+
+
+
+semantic versioning 시스템
+
+`v2.0.0` major minor fix
+
+- major 번호 - 어떤 기능이 추가되었을 때, 전체적인 업데이트
+- minor 번호 - 커다란 기능 중 조금의 기능들이 업데이트 되거나 개선되었을 때
+- fix 번호 - 존재하는 기능에서 오류 수정, 성능 개선했을 때 
+
+### 3.15 태그 데모
+
+특정 커밋에 태그를 달고 싶다면 `git tag 원하는문자열 해시번호`
+
+태그를 상세하게 작성하고 싶다면? `git tag 내용 해시번호 -am "내용" `a는 annotate
+
+`git tag`는 모든 태그 확인 가능
+
+git checkout 명령어를 이용하면 태그 버전으로 이동 가능하다
+
+서버에 태그를 올리고 싶다면 `git push origin v1.0.0`
+
+## 4. 브랜치의 모든것
+
+### 4.1 브랜치를 왜 꼭 써야 할까?
+
+Branch는 협업을 위해 필수이다.
+
+git에서 따로 지정을 하지 않는 이상 master 브랜치가 사용된다. 별도로 브랜치를 생성하지 않으면 master 브랜치에서 하나의 줄기로 커밋이 생긴다. 일반적으로 master 브랜치는 코드가 검증되고 기능에 문제 없는 코드만 포함되어 있다. 만약 새로운 기능이 필요하다면 feature 브랜치를 생성해 커밋을 남긴다.
+
+이때 HEAD는 master 브랜치에서 분기되어 최신 feature 브랜치의 커밋을 가리키고 있다. feature 브랜치에서 기능 구현이 완료 되었다면 master 브랜치에 merge한다. merge를 마친 브랜치는 삭제하고 남겼던 커밋들은 master 브랜치에 남긴다. 하지만 대부분은 feature 브랜치에서 작업했던 커밋들을 하나로 만들어 해당 커밋 하나만 master 브랜치에 남긴다. 
+
+하나의 커밋으로 깔끔하게 만들어서 sqush merge한다. 
+
+### 4.2 브랜치 기본 사용법
+
+`git branch` 로컬의 브랜치 목록
+
+`git branch --all`: 로컬과 서버를 포함한 브랜치 목록
+
+`git checkout`을 이용하면 원하는 버전, 브랜치로 이동 가능하다.
+
+ `git checkout -b 브랜치명`, `git switch -c 브랜치명`
+
+### 4.3 머지란? fast-forward merge
+
+fast-forward merges는 머지되었다는 히스토리가 남지 않는다. 


### PR DESCRIPTION
드림코딩 git 강의 구매해 놓은거 들으면서 정리만 했습니다.

## 2. 셋업하기

### 2.1 필요한 아이들 설치

터미널에서 명령어를 사용하는 것을 추천

### 2.2 사용자 설정 및 필요한 셋팅들

windows: `git config --global core.autocrlf true`

mac: `git config --global core.autocrlf input`

운영체제마다 줄바꿈을 할 때 들어가는 문자열이 다르기 때문에 

Windows는 `\r\n` carriage-return과 line feed

mac은 `\n` line feed

이러한 설정 때문에 변경 사항이 없더라도 줄바꿈 문자열이 달라져서 

`core.autocrlf`는 줄바꿈 문자를 설정할 수 있다. Windows의 경우 true로 설정하면 git에 저장할 때는 `\r`을 삭제한 `\n`만 저장이 되고 가져올 때는 자동으로 `\r`이 붙어져 `\r\n`을 가져온다. 

Mac에서 input으로 설정하면 `\r`을 삭제하여 git에 저장한다. carriage-return을 사용하지 않음에도 이를 삭제하는 이유는 복사해서 가져온 텍스트에 carriage-return이 들어가 있을 수 있기 때문이다. 

### 2.3 깃을 공부하는 포인트

Git에 관련된 전체적인 명령어를 이해하고 사용하는 연습

`git 명령어 -옵션`

### 2.4 깃 초기화 하고 삭제하기

`mkdir git`: 폴더 생성

`cd git`: 폴더로 이동

`git init`: git 초기화 -> `.git` 폴더 생성. git repository와 관련된 정보를 포함.

`rm -rf .git`: git 삭제

#### git alias 사용하기

`git config --global alias.st status` 라고 별칭(alias)를 지정하면 git status 명령어 대신 git st로 사용할 수 있다. 

`git config --h`: git 명령어 확인

## 3. 기본 명령어 정복하기

### 3.1 깃의 중요한 컨셉 이해하기

깃을 잘 이해하기 위해서는 workflow를 이해하는 것이 중요하다.

git은 총 3가지의 작업 환경으로 나누어져 있다. 

- working directory: 파일들을 수정하는 작업 디렉토리
- staging area: 버전 히스토리에 저장할 수 있는 파일 장소
- .git directiory: 버전의 히스토리를 가지고 있는 깃 리파지토리



작업을 하고 있는 디렉토리(working directory)에서 수정을 마치면 staging area로 옮긴다. commit 이라는 명령어를 이용해 staging area에 있는 파일들을 깃 버전 히스토리(.git directory)에 저장한다. 

git directory에 저장된 파일들은 checkout 명령어를 이용해 언제든지 원하는 버전으로 이동할 수 있다.

git history는 로컬 컴퓨터에만 저장되기 때문에 문제가 생기면 파일들이 없어질 수 있다. 그렇기 때문에 다른 서버에 저장할 필요가 있다. push 명령어를 이용해서 서버에 .git directory를 업로드할 수 있다. 

서버에서 로컬로 다운로드 받고 싶을 때는 pull 명령어. 각각의 버전에 포함된 정보는 다음과 같다.

- snapshot된 정보를 기반으로 고유한 hash 코드를 생성하고 hash code를 아이디로 정보를 참조할 수 있다. 아이디 뿐만 아니라 버전에 관한 메시지와 변경자와 변경시간 등의 정보도 포함한다.

working directory는 untracked와 tracked로 나뉜다.

- untracked: 새로 만들어졌거나 git이 존재하던 폴더에서 git 폴더를 삭제했을 때
- tracked: git이 이미 관리하고 있는 파일
  - git이 추적하고 있는 파일들 중 수정이 되었는지 여부에 따라 modified와 unmodified로 구분
    - unmodified는 이전 버전과 비교해 변경되지 않았기 때문에 수정이 된 modified만 파일만 staging area로 이동할 수 있다. 

### 3.2 로컬 파일들 추가하기 add

변경점이 생겼을 때 commit하지 않은 파일들을 

`git status`: 현재 파일들의 상태 확인

`git add`: staging area로 옮길 파일을 추가

`git rm --cached *`: git add한 파일들을 untracked로 변경 

`*`는 디렉토리의 모든 파일을 의미. 만약 파일이 삭제되었다면? staging area에 추가되지 않는다.

`.`은 모든 파일들을 포함해 staging area에 추가한다. 

### 3.3  절대 추가 하면 안되는 아이들 ignore

gitignore은 추적하고 싶지 않은, git과 github에 올리고 싶지 않은 파일을 정의한다.

### 3.4 현재 상태 확인하기 status

`git status`는 작업 내용들을 간단하게 확인할 수 있는 명령어

`git status -h`를 입력하면 git status에 대한 명령어를 자세히 알고 싶을 때

`git status -s` 간단하게 확인 가능

### 3.5 파일 비교하기 diff

git status는 어떤 파일이 수정되었고 staging area에 있는지 확인할 수는 있지만 정확히 어떤 내용이 수정되었는 지는 확인할 수 없다. 

`git diff`를 입력하면 working directory를 기준으로 변경사항을 확인

`@@ -1 +1,2 @@` 의미 `-1`은 이전 파일, `+1,2`는 현재 파일에서 첫 번째 라인에서 두 줄을 확인하라는 뜻

### 3.6 버전 등록하기 commit

서버에 올릴 파일들을 staging area에 옮겨 놓았다. 첫 번째 버전을 만들어 보자.

버전을 만들 때는 commit 명령어를 사용한다. 

`git commit`

`[브랜치 해시코드 앞부분] 제목`

`git log` 깃 히스토리 확인

`git commit -m "커밋 메시지"`

모든 변경점을 한 번에 올리려면 `git commit -am "커밋 메시지"`

### 3.7 커밋할 때 팁

로컬에 있는 .git directory는 history가 모여 있다. 작업한 내용들을 버전으로 나누어 관리할 수 있도록.

history에는 전체 애플리케이션을 만들어 저장하는 것이 아니라 세분화, 기능별로 나누는 것이 중요하다. 또한, 의미없는 커밋보다는 작업단위, 의미 있는 이름을 부여해 작업 내용을 확인할 수 있고 원하지 않은 변경사항을 취소할 수 있다. 

커밋 메시지는 현재형으로, 동사로 만들어진다. init, add, fix 

커밋 메시지 작성할 때 주의할 점: 하나의 커밋에 다른 내용들을 끼워넣지 않을 것. 코드를 리뷰할 때 혼동이 올 뿐만 아니라 히스토리를 추적하기 어렵다. 

너무 크지도, 작지도 않게 의미 있는 단위로 커밋하기

### 3.8 소스트리로 커밋하기



### 3.9 파일 변경시 유용한 팁

파일을 삭제할 때는 `rm` 명령어를 사용하면 파일이 삭제된 내용은 staging area에 포함되지 않는다. 커밋하기 위해서는 add를 해야한다. `git rm` 명령어를 이용해 파일을 삭제하면 바로 staging area에 추가해준다. 

`mv a b` 파일 이름을 변경할 때는 기존의 파일(a)이 삭제되었고 b가 새로 생성되었다고 간주한다.

`git mv a b`를 이용하면 이름이 변경된 것이 바로 staging area에 추가된다.

### 3.10 버전들 목록 보기 log

git history를 볼 수 있는 `git log` - 위에가 최신 아래가 옛날

`git log --p`: 수정된 파일 내용도 확인 가능 (변경된 파일 내용도 확인하고 싶을 때 )

`git log --oneline` 간단하게 히스토리를 확인



`HEAD`란?  

a라는 커밋을 하고 b,c 를 차례로 커밋 했다고 하자. 그렇다면 b는 a를 c는 b를 '참조'하고 있다. b가 a를 가리키는 포인터가 생성이 된다. HEAD는 지금 현재 시점의 버전. 

`HEAD~1`은 현재 HEAD의 하나 이전 버전.

이렇게 만들어진 커밋들은 원할 때 언제든지 돌아갈 수 있다. b로 돌아가고 싶다면 checkout 

head는 현재 바라보고 있는 커밋을 가리킨다는 의미이다. git log를 하면 해시코드가 있다. 해시코드를 복사한 다음 `git checkout 해시코드`를 입력하면 해당 커밋으로 돌아간다. 

### 3.11 로그 이쁘게 만들기 (엘리의 포맷 공유)

git log를 볼 때 원하는 정보를 볼 수 있도록 포맷팅 하는 방법

`git log --pretty=oneline` 

원하는 방식대로 포맷을 만들 수 있다.

`git log --pretty=format:"$h $an $ar $s"`

`git log --oneline --graph --all` 



`git config --global alias.hist "git log --graph --all --pretty=format:'%C(yellow)[%ad]%C(reset) %C(green)[%h]%C(reset) | %C(white)%s %C(bold red){{%an}}%C(reset) %C(blue)%d%C(reset)' --date=short"` 그래프까지 포함해 예쁘게 로그 보는 방법

### 3.12 로그 심화 내용

깃 로그를 잘 활용한다는 것은 깃 히스토리를 잘 확인하고 원하는 버전을 빠르게 찾아낼 수 있기 때문이다. 

`git log -3`: 최근 3개의 커밋 확인

### 3.14 태그는 왜 필요할까? tag

깃 히스토리에 커밋이 쌓이고 로그가 길어진다면 특정 시점으로 돌아가기 어렵다.

커밋에 태그를 달아두면 원하는 시점으로 쉽게 돌아갈 수 있다. 대부분 release할 때 버전을 많이 태그해둔다. 태그는 특정 부분에 태그를 해둠으로써 언제 release 되었는지 확인하고 



semantic versioning 시스템

`v2.0.0` major minor fix

- major 번호 - 어떤 기능이 추가되었을 때, 전체적인 업데이트
- minor 번호 - 커다란 기능 중 조금의 기능들이 업데이트 되거나 개선되었을 때
- fix 번호 - 존재하는 기능에서 오류 수정, 성능 개선했을 때 

### 3.15 태그 데모

특정 커밋에 태그를 달고 싶다면 `git tag 원하는문자열 해시번호`

태그를 상세하게 작성하고 싶다면? `git tag 내용 해시번호 -am "내용" `a는 annotate

`git tag`는 모든 태그 확인 가능

git checkout 명령어를 이용하면 태그 버전으로 이동 가능하다

서버에 태그를 올리고 싶다면 `git push origin v1.0.0`

## 4. 브랜치의 모든것

### 4.1 브랜치를 왜 꼭 써야 할까?

Branch는 협업을 위해 필수이다.

git에서 따로 지정을 하지 않는 이상 master 브랜치가 사용된다. 별도로 브랜치를 생성하지 않으면 master 브랜치에서 하나의 줄기로 커밋이 생긴다. 일반적으로 master 브랜치는 코드가 검증되고 기능에 문제 없는 코드만 포함되어 있다. 만약 새로운 기능이 필요하다면 feature 브랜치를 생성해 커밋을 남긴다.

이때 HEAD는 master 브랜치에서 분기되어 최신 feature 브랜치의 커밋을 가리키고 있다. feature 브랜치에서 기능 구현이 완료 되었다면 master 브랜치에 merge한다. merge를 마친 브랜치는 삭제하고 남겼던 커밋들은 master 브랜치에 남긴다. 하지만 대부분은 feature 브랜치에서 작업했던 커밋들을 하나로 만들어 해당 커밋 하나만 master 브랜치에 남긴다. 

하나의 커밋으로 깔끔하게 만들어서 sqush merge한다. 

### 4.2 브랜치 기본 사용법

`git branch` 로컬의 브랜치 목록

`git branch --all`: 로컬과 서버를 포함한 브랜치 목록

`git checkout`을 이용하면 원하는 버전, 브랜치로 이동 가능하다.

 `git checkout -b 브랜치명`, `git switch -c 브랜치명`

### 4.3 머지란? fast-forward merge

fast-forward merges는 머지되었다는 히스토리가 남지 않는다. 