### PR TITLE
[손창성] React Router 사용해서 라우팅 하기

### DIFF
--- a/scs/2024-03-28.md
+++ b/scs/2024-03-28.md
@@ -1,0 +1,178 @@
+## React Router DOM을 사용해서 라우팅하기
+
+> [React Router의 공식 문서](https://reactrouter.com/en/main/start/tutorial)를 활용 v6.22.3 
+
+### 1. React Router DOM 설치
+
+```
+yarn add react-router-dom
+```
+
+### 2. 라우터 추가
+
+`createBrowserRouter`를 사용하여 라우터를 생성하고, 애플리케이션의 라우트 구조를 정의한다. `createBrowserRouter`는 라우터 구성을 객체 형태로 선언적으로 만들 수 있게 해주며, 이를 통해 라우트의 구조와 관련 컴포넌트를 보다 명확하게 구성할 수 있다. 
+
+`path`는 사용자가 특정 위치(URL)로 이동했을 때 보여줄 페이지 또는 컴포넌트를 결정하는 규칙이다. `element`는 특정 `path`로 이동했을 때 실제로 화면에 렌더링될 컴포넌트를 지정한다.
+
+```tsx
+// Router.tsx
+import { createBrowserRouter } from 'react-router-dom';
+
+export const router = createBrowserRouter([
+  {
+    path: "/",
+    element: <div>Hello world!</div>,
+  },
+]);
+```
+
+### 3. 라우터를 전체 애플리케이션에 적용
+
+생성한 라우터를 애플리케이션에 적용하기 위해 `RouterProvider` 컴포넌트를 사용한다. 이 컴포넌트에 `router` prop을 전달하여, 애플리케이션 전체에 라우팅을 적용할 수 있다.
+
+> `main.tsx`은 애플리케이션의 진입점으로 사용되는 파일이다. React 애플리케이션의 최상위 컴포넌트로서, 애플리케이션을 구성하는 루트 컴포넌트를 렌더링하는 역할을 한다. 
+
+```tsx
+// main.tsx
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { RouterProvider } from 'react-router-dom';
+import { router } from './Router';
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <RouterProvider router={router} />
+  </React.StrictMode>
+);
+```
+
+### 4. 페이지 및 컴포넌트 구현
+
+기능에 따라 필요한 페이지를 정의해보았다.
+
+- `/` - 전체 아티클을 볼 수 있는 메인 페이지
+  - `/topics/:major` - 대분류 주제에 대한 페이지
+  - `/topics/:major/:sub` - 소분류 주제에 대한 상세 페이지
+  - `/bookmark` - 사용자가 북마크한 콘텐츠나 페이지를 모아 볼 수 있는 페이지
+  - `/profile/:id` - 사용자의 프로필 페이지
+  - `/search/:query` - 사용자가 입력한 검색 결과를 보여주는 페이지
+  - `*`: 정의되지 않은 경로에 접근했을 때 보여주는 페이지
+
+이를 토대로 페이지 컴포넌트를 생성하고 해당 경로에 해당하는 컴포넌트를 렌더링하도록 라우터 설정을 변경한다.
+
+```
+📦linkeeper
+ ┣ 📂src
+ ┃ ┣ 📂pages
+ ┃ ┃ ┣ 📜Bookmark.tsx
+ ┃ ┃ ┣ 📜Home.tsx
+ ┃ ┃ ┣ 📜index.ts
+ ┃ ┃ ┣ 📜MajorTopic.tsx
+ ┃ ┃ ┣ 📜NotFound.tsx
+ ┃ ┃ ┣ 📜Profile.tsx
+ ┃ ┃ ┣ 📜SearchResults.tsx
+ ┃ ┃ ┗ 📜SubTopic.tsx
+```
+
+```tsx
+// Router.tsx
+import { createBrowserRouter } from 'react-router-dom';
+import Root from './Root';
+import {
+  Home,
+  NotFound,
+  MajorTopic,
+  SubTopic,
+  Bookmark,
+  SearchResults,
+  Profile,
+} from './pages';
+
+export const router = createBrowserRouter([
+  {
+    path: '/',
+    element: <Root />,
+    errorElement: <NotFound />, // 오류 발생(예: 경로 매칭 실패) 시 보여줄 컴포넌트를 지정
+    children: [
+      // index 속성은 상위 경로의 경로가 정확히 일치할 때 렌더링되는 기본 경로를 정의
+      { path: '/', element: <Home />, index: true },
+      {
+        path: '/topics/:major',
+        element: <MajorTopic />,
+      },
+      {
+        path: '/topics/:major/:sub',
+        element: <SubTopic />,
+      },
+      { path: '/bookmark', element: <Bookmark /> },
+      { path: '/search/:query', element: <SearchResults /> },
+      { path: '/profile/:id', element: <Profile /> },
+    ],
+  },
+]);
+```
+
+데이터의 식별자(ID)나 어떤 변수 값이 URL에 사용될 때 애플리케이션의 URL 경로 일부가 변하는 경우가 있다. React Router에서는 이렇게 동적으로 변하는 URL을 처리하기 위해 **동적 세그먼트**를 사용한다. 
+
+예를 들어 프로필 페이지의 경로를 설정할 때 각 사용자의 고유 ID로 페이지를 구분한다고 하면 `/profile/:id`와 같이 경로를 설정할 수 있다. `:id`는 동적으로 변경되는 부분으로, 실제 사용자 ID로 대체된다. URL과 문자열이 일치하지는 않지만 동적으로 일치한다는 의미이다.
+
+동적 경로를 사용하면 하나의 경로 설정으로 다양한 페이지를 처리할 수 있다. 
+
+```tsx
+// Root.tsx
+import { Outlet } from 'react-router-dom';
+
+export default function Root() {
+  return (
+    <>
+      {/* TODO: Header, Footer, Main 등 레이아웃 요소 추가 */}
+      <Outlet />
+    </>
+  );
+}
+```
+
+`Outlet` 컴포넌트는 중첩 라우팅을 구현할 때 사용한다. 라우터에서 정의한 경로와 일치하는 컴포넌트로 대체되어 렌더링된다. 예를 들어 `/bookmark`로 이동하면 `Outlet` 컴포넌트는 URL과 매칭되는 컴포넌트 `<Bookmark />`로 대체된다.
+
+```tsx
+export const router = createBrowserRouter([
+  {
+    path: '/',
+    element: <Root />,
+    errorElement: <NotFound />,
+    children: [
+      { path: '/', element: <Home />, index: true },
+      {
+        path: '/topics/:major',
+        element: <MajorTopic />,
+      },
+      {
+        path: '/topics/:major/:sub',
+        element: <SubTopic />,
+      },
+      { path: '/bookmark', element: <Bookmark /> },
+      { path: '/search/:query', element: <SearchResults /> },
+      { path: '/profile/:id', element: <Profile /> },
+    ],
+  },
+]);
+```
+
+중첩 라우팅 구조를 구성하기 위해 `children` 속성을 사용하여 하위 라우트를 정의할 수 있다. 위에서 정의한 라우터는 `/` 루트 경로의 자식으로 각 경로들이 정의되어 있다. 
+
+`Outlet`을 사용하면, 부모-자식 관계에 있는 라우트 간에 컴포넌트를 효과적으로 구성할 수 있다. 이를 활용한 예로 공통 레이아웃 요소를 여러 페이지에서 사용할 수 있게 하는 것이다.
+
+![result](https://scseong.github.io/assets/images/2024-03-28-240328TIL/image-20240328212715470.png)
+
+공통 레이아웃인 Header와 Sidebar, Footer는 그대로 두고 Main 영역에서만 페이지마다 다른 컨텐츠를 보여주고자 한다. `Root.tsx` 애플리케이션의 루트에서 공통 레이아웃을 정의하고 자식 라우트의 컴포넌트가 렌더링될 위치를 `Outlet`으로 지정한다. 이렇게 하면 공통 레이아웃을 유지하면서 페이지마다 고유한 컨텐츠를 렌더링 할 수 있다.
+
+### 구현
+
+![result](https://scseong.github.io/assets/images/2024-03-28-240328TIL/result.gif)
+
+
+## 참고자료
+
+- [The Power Of CreateBrowserRouter: Optimizing Your React App's Navigation](https://www.dhiwise.com/post/the-power-of-createbrowserrouter-optimizing-your-react-app)
+- [createBrowserRouter를 통한 Router기능 추가](https://velog.io/@adultlee/createBrowserRouter%EB%A5%BC-%ED%86%B5%ED%95%9C-Router%EA%B8%B0%EB%8A%A5-%EC%B6%94%EA%B0%80)
+- [React Router 공식 문서](https://reactrouter.com/en/main/start/concepts)


### PR DESCRIPTION
## React Router DOM을 사용해서 라우팅하기

> [React Router의 공식 문서](https://reactrouter.com/en/main/start/tutorial)를 활용 v6.22.3 

### 1. React Router DOM 설치

```
yarn add react-router-dom
```

### 2. 라우터 추가

`createBrowserRouter`를 사용하여 라우터를 생성하고, 애플리케이션의 라우트 구조를 정의한다. `createBrowserRouter`는 라우터 구성을 객체 형태로 선언적으로 만들 수 있게 해주며, 이를 통해 라우트의 구조와 관련 컴포넌트를 보다 명확하게 구성할 수 있다. 

`path`는 사용자가 특정 위치(URL)로 이동했을 때 보여줄 페이지 또는 컴포넌트를 결정하는 규칙이다. `element`는 특정 `path`로 이동했을 때 실제로 화면에 렌더링될 컴포넌트를 지정한다.

```tsx
// Router.tsx
import { createBrowserRouter } from 'react-router-dom';

export const router = createBrowserRouter([
  {
    path: "/",
    element: <div>Hello world!</div>,
  },
]);
```

### 3. 라우터를 전체 애플리케이션에 적용

생성한 라우터를 애플리케이션에 적용하기 위해 `RouterProvider` 컴포넌트를 사용한다. 이 컴포넌트에 `router` prop을 전달하여, 애플리케이션 전체에 라우팅을 적용할 수 있다.

> `main.tsx`은 애플리케이션의 진입점으로 사용되는 파일이다. React 애플리케이션의 최상위 컴포넌트로서, 애플리케이션을 구성하는 루트 컴포넌트를 렌더링하는 역할을 한다. 

```tsx
// main.tsx
import React from 'react';
import ReactDOM from 'react-dom/client';
import { RouterProvider } from 'react-router-dom';
import { router } from './Router';

ReactDOM.createRoot(document.getElementById('root')!).render(
  <React.StrictMode>
    <RouterProvider router={router} />
  </React.StrictMode>
);
```

### 4. 페이지 및 컴포넌트 구현

기능에 따라 필요한 페이지를 정의해보았다.

- `/` - 전체 아티클을 볼 수 있는 메인 페이지
  - `/topics/:major` - 대분류 주제에 대한 페이지
  - `/topics/:major/:sub` - 소분류 주제에 대한 상세 페이지
  - `/bookmark` - 사용자가 북마크한 콘텐츠나 페이지를 모아 볼 수 있는 페이지
  - `/profile/:id` - 사용자의 프로필 페이지
  - `/search/:query` - 사용자가 입력한 검색 결과를 보여주는 페이지
  - `*`: 정의되지 않은 경로에 접근했을 때 보여주는 페이지

이를 토대로 페이지 컴포넌트를 생성하고 해당 경로에 해당하는 컴포넌트를 렌더링하도록 라우터 설정을 변경한다.

```
📦linkeeper
 ┣ 📂src
 ┃ ┣ 📂pages
 ┃ ┃ ┣ 📜Bookmark.tsx
 ┃ ┃ ┣ 📜Home.tsx
 ┃ ┃ ┣ 📜index.ts
 ┃ ┃ ┣ 📜MajorTopic.tsx
 ┃ ┃ ┣ 📜NotFound.tsx
 ┃ ┃ ┣ 📜Profile.tsx
 ┃ ┃ ┣ 📜SearchResults.tsx
 ┃ ┃ ┗ 📜SubTopic.tsx
```

```tsx
// Router.tsx
import { createBrowserRouter } from 'react-router-dom';
import Root from './Root';
import {
  Home,
  NotFound,
  MajorTopic,
  SubTopic,
  Bookmark,
  SearchResults,
  Profile,
} from './pages';

export const router = createBrowserRouter([
  {
    path: '/',
    element: <Root />,
    errorElement: <NotFound />, // 오류 발생(예: 경로 매칭 실패) 시 보여줄 컴포넌트를 지정
    children: [
      // index 속성은 상위 경로의 경로가 정확히 일치할 때 렌더링되는 기본 경로를 정의
      { path: '/', element: <Home />, index: true },
      {
        path: '/topics/:major',
        element: <MajorTopic />,
      },
      {
        path: '/topics/:major/:sub',
        element: <SubTopic />,
      },
      { path: '/bookmark', element: <Bookmark /> },
      { path: '/search/:query', element: <SearchResults /> },
      { path: '/profile/:id', element: <Profile /> },
    ],
  },
]);
```

데이터의 식별자(ID)나 어떤 변수 값이 URL에 사용될 때 애플리케이션의 URL 경로 일부가 변하는 경우가 있다. React Router에서는 이렇게 동적으로 변하는 URL을 처리하기 위해 **동적 세그먼트**를 사용한다. 

예를 들어 프로필 페이지의 경로를 설정할 때 각 사용자의 고유 ID로 페이지를 구분한다고 하면 `/profile/:id`와 같이 경로를 설정할 수 있다. `:id`는 동적으로 변경되는 부분으로, 실제 사용자 ID로 대체된다. URL과 문자열이 일치하지는 않지만 동적으로 일치한다는 의미이다.

동적 경로를 사용하면 하나의 경로 설정으로 다양한 페이지를 처리할 수 있다. 

```tsx
// Root.tsx
import { Outlet } from 'react-router-dom';

export default function Root() {
  return (
    <>
      {/* TODO: Header, Footer, Main 등 레이아웃 요소 추가 */}
      <Outlet />
    </>
  );
}
```

`Outlet` 컴포넌트는 중첩 라우팅을 구현할 때 사용한다. 라우터에서 정의한 경로와 일치하는 컴포넌트로 대체되어 렌더링된다. 예를 들어 `/bookmark`로 이동하면 `Outlet` 컴포넌트는 URL과 매칭되는 컴포넌트 `<Bookmark />`로 대체된다.

```tsx
export const router = createBrowserRouter([
  {
    path: '/',
    element: <Root />,
    errorElement: <NotFound />,
    children: [
      { path: '/', element: <Home />, index: true },
      {
        path: '/topics/:major',
        element: <MajorTopic />,
      },
      {
        path: '/topics/:major/:sub',
        element: <SubTopic />,
      },
      { path: '/bookmark', element: <Bookmark /> },
      { path: '/search/:query', element: <SearchResults /> },
      { path: '/profile/:id', element: <Profile /> },
    ],
  },
]);
```

중첩 라우팅 구조를 구성하기 위해 `children` 속성을 사용하여 하위 라우트를 정의할 수 있다. 위에서 정의한 라우터는 `/` 루트 경로의 자식으로 각 경로들이 정의되어 있다. 

`Outlet`을 사용하면, 부모-자식 관계에 있는 라우트 간에 컴포넌트를 효과적으로 구성할 수 있다. 이를 활용한 예로 공통 레이아웃 요소를 여러 페이지에서 사용할 수 있게 하는 것이다.

![result](https://scseong.github.io/assets/images/2024-03-28-240328TIL/image-20240328212715470.png)

공통 레이아웃인 Header와 Sidebar, Footer는 그대로 두고 Main 영역에서만 페이지마다 다른 컨텐츠를 보여주고자 한다. `Root.tsx` 애플리케이션의 루트에서 공통 레이아웃을 정의하고 자식 라우트의 컴포넌트가 렌더링될 위치를 `Outlet`으로 지정한다. 이렇게 하면 공통 레이아웃을 유지하면서 페이지마다 고유한 컨텐츠를 렌더링 할 수 있다.

### 구현

![result](https://scseong.github.io/assets/images/2024-03-28-240328TIL/result.gif)


## 참고자료

- [The Power Of CreateBrowserRouter: Optimizing Your React App's Navigation](https://www.dhiwise.com/post/the-power-of-createbrowserrouter-optimizing-your-react-app)
- [createBrowserRouter를 통한 Router기능 추가](https://velog.io/@adultlee/createBrowserRouter%EB%A5%BC-%ED%86%B5%ED%95%9C-Router%EA%B8%B0%EB%8A%A5-%EC%B6%94%EA%B0%80)
- [React Router 공식 문서](https://reactrouter.com/en/main/start/concepts)